### PR TITLE
feat: add App Store link and Smart App Banner for Медичні Коди

### DIFF
--- a/next-personal-site/src/app/(narrow)/apps/medical-codes/page.tsx
+++ b/next-personal-site/src/app/(narrow)/apps/medical-codes/page.tsx
@@ -3,10 +3,16 @@ import Image from "next/image";
 import Link from "next/link";
 import { Search, BookmarkCheck, Globe, WifiOff, Moon, Layers } from "lucide-react";
 
+const appStoreUrl =
+    "https://apps.apple.com/ua/app/%D0%BC%D0%B5%D0%B4%D0%B8%D1%87%D0%BD%D1%96-%D0%BA%D0%BE%D0%B4%D0%B8/id6758305387";
+
 export const metadata: Metadata = {
     title: "Медичні Коди — АКМІ та МКХ-10 для iOS",
     description:
         "Безкоштовний iOS-додаток для пошуку медичних кодів АКМІ (ACHI) та МКХ-10 (ICD-10). Понад 23 000 кодів офлайн, українською та англійською.",
+    other: {
+        "apple-itunes-app": "app-id=6758305387",
+    },
 };
 
 export default function MedichniKodiPage() {
@@ -28,6 +34,15 @@ export default function MedichniKodiPage() {
                     Довідник кодів АКМІ та МКХ-10 у вашому iPhone. Понад 23 000
                     медичних кодів офлайн.
                 </p>
+                <Link
+                    href={appStoreUrl}
+                    className="mt-4 inline-flex items-center gap-2 rounded-xl bg-black px-5 py-3 text-white text-sm font-medium hover:bg-gray-800 transition-colors dark:bg-white dark:text-black dark:hover:bg-gray-200"
+                >
+                    <svg viewBox="0 0 384 512" className="h-5 w-5 fill-current">
+                        <path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z" />
+                    </svg>
+                    Завантажити в App Store
+                </Link>
             </section>
 
             {/* Screenshots */}

--- a/next-personal-site/src/app/(narrow)/page.mdx
+++ b/next-personal-site/src/app/(narrow)/page.mdx
@@ -43,6 +43,7 @@
   iOS app for looking up Ukrainian medical classification codes: АКМІ (ACHI) with 6,728 procedure codes and МКХ-10 (ICD-10) with 16,960 diagnosis codes. Fully offline, bilingual (Ukrainian & English).
 
   * [More details](/apps/medical-codes)
+  * [App Store](https://apps.apple.com/ua/app/%D0%BC%D0%B5%D0%B4%D0%B8%D1%87%D0%BD%D1%96-%D0%BA%D0%BE%D0%B4%D0%B8/id6758305387)
   * Telegram Bot: https://t.me/achi_selector_bot
   * GitHub: https://github.com/solomkinmv/medical-classification
 


### PR DESCRIPTION
## Summary
- Add "Завантажити в App Store" download button on the medical-codes page
- Add App Store link to the Medical Codes project section on the homepage
- Add `apple-itunes-app` meta tag for the iOS Smart App Banner (Safari will show a banner suggesting to open/install the app)

## Test plan
- [ ] Verify the download button renders on `/apps/medical-codes`
- [ ] Verify the App Store link appears on the homepage
- [ ] Verify the Smart App Banner meta tag is present in the page source on `/apps/medical-codes`